### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/ecabrera0851/0fdd6cc5-3211-47cf-96ce-b66f292b2731/f671fa1f-4e7b-4246-b180-824a8f614f5e/_apis/work/boardbadge/48804917-b96a-4527-ae6e-0e92295eee13)](https://dev.azure.com/ecabrera0851/0fdd6cc5-3211-47cf-96ce-b66f292b2731/_boards/board/t/f671fa1f-4e7b-4246-b180-824a8f614f5e/Microsoft.RequirementCategory)
 # webPage
 readme de reporsitorio


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ecabrera0851/0fdd6cc5-3211-47cf-96ce-b66f292b2731/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.